### PR TITLE
Add quick user switch button to exercise screen

### DIFF
--- a/app.js
+++ b/app.js
@@ -344,6 +344,11 @@ class GymTracker {
                 this.hideImportResultModal();
             }
         });
+
+        // Switch user button
+        document.getElementById('switch-user-btn').addEventListener('click', () => {
+            this.switchUser();
+        });
     }
 
     // Navigation
@@ -359,6 +364,7 @@ class GymTracker {
         const profile = this.data.profiles[profileKey];
         document.getElementById('profile-title').textContent = profile.name;
         this.updateMuscleGroupButtons();
+        this.updateUserSwitchButton();
         this.showScreen('muscle-groups');
     }
 
@@ -565,6 +571,31 @@ class GymTracker {
             const displayName = this.data.muscleGroupNames ? this.data.muscleGroupNames[group] : this.capitalize(group);
             btn.querySelector('span').textContent = displayName;
         });
+    }
+
+    switchUser() {
+        // Get all available profiles
+        const profileKeys = Object.keys(this.data.profiles);
+        const currentIndex = profileKeys.indexOf(this.currentProfile);
+        const nextIndex = (currentIndex + 1) % profileKeys.length;
+        const nextProfile = profileKeys[nextIndex];
+        
+        // Switch to the next profile while staying on the same muscle group
+        const currentMuscleGroup = this.currentMuscleGroup;
+        this.selectProfile(nextProfile);
+        
+        // If we were on the exercises screen, go back to the same muscle group
+        if (currentMuscleGroup && this.data.profiles[nextProfile].exercises[currentMuscleGroup]) {
+            this.selectMuscleGroup(currentMuscleGroup);
+        }
+    }
+
+    updateUserSwitchButton() {
+        const userInitial = document.getElementById('current-user-initial');
+        if (userInitial && this.currentProfile) {
+            const profile = this.data.profiles[this.currentProfile];
+            userInitial.textContent = profile.name.charAt(0).toUpperCase();
+        }
     }
 
     populateHistory(exerciseName) {

--- a/index.html
+++ b/index.html
@@ -130,7 +130,13 @@
                     <h1 id="muscle-group-title">Back</h1>
                     <button class="edit-name-btn" id="edit-muscle-group-btn" title="Edit muscle group name">✏️</button>
                 </div>
-                <button class="add-btn" id="add-exercise-btn">+</button>
+                <div class="header-actions">
+                    <button class="switch-user-btn" id="switch-user-btn" title="Switch user">
+                        <span class="user-initial" id="current-user-initial">E</span>
+                        ⇄
+                    </button>
+                    <button class="add-btn" id="add-exercise-btn">+</button>
+                </div>
             </header>
             
             <div id="exercises-list" class="exercises-list">

--- a/styles.css
+++ b/styles.css
@@ -151,6 +151,46 @@ body {
     flex: 1;
 }
 
+.header-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.switch-user-btn {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    color: var(--text-primary);
+    font-size: 0.9rem;
+    padding: 8px 12px;
+    cursor: pointer;
+    border-radius: 20px;
+    transition: var(--transition);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-height: 40px;
+    font-weight: 500;
+}
+
+.switch-user-btn:hover {
+    background-color: var(--bg-tertiary);
+    transform: translateY(-1px);
+}
+
+.user-initial {
+    background: var(--accent-primary);
+    color: white;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
 /* Profile Selector */
 .profile-selector {
     display: flex;


### PR DESCRIPTION
## Summary
- Added a quick user switch button to the exercise screen header
- Button displays current user's initial with a switch arrow (⇄) 
- Enables seamless switching between Elena and Adri while staying on the same muscle group
- Styled with a pill design that matches the app's aesthetic

## Features
- **Quick Toggle**: Click to cycle between available users
- **Context Preservation**: Maintains current muscle group when switching
- **Visual Feedback**: Shows current user's initial in the button
- **Responsive Design**: Integrates smoothly with existing header layout

## Test Plan
- [x] Button appears in exercises screen header
- [x] Clicking switches between users (Elena ↔ Adri)
- [x] Current muscle group is preserved during switch
- [x] User initial updates correctly in button
- [x] Button styling matches app design
- [x] Works with existing export/import functionality

🤖 Generated with [Claude Code](https://claude.ai/code)